### PR TITLE
Match on dry-monads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-# TODO: remove once 'dry-monads' pushed to rubygems.org
-gem "dry-monads", github: "dry-rb/dry-monads"
-
 group :test do
   gem "codeclimate-test-reporter", require: nil
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 # TODO: remove once 'dry-monads' pushed to rubygems.org
-# run `rake install:local` from dry-monads
-gem "dry-monads", "0.0.1"
+gem "dry-monads", github: "dry-rb/dry-monads"
 
 group :test do
   gem "codeclimate-test-reporter", require: nil

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,14 @@ source "https://rubygems.org"
 
 gemspec
 
+# TODO: remove once 'dry-monads' pushed to rubygems.org
+# run `rake install:local` from dry-monads
+gem "dry-monads", "0.0.1"
+
 group :test do
   gem "codeclimate-test-reporter", require: nil
+end
+
+group :tools do
+  gem "pry"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     dry-result_matcher (0.3.0)
-      kleisli
+      dry-monads (~> 0.0.0)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +14,6 @@ GEM
     docile (1.1.5)
     dry-monads (0.0.1)
     json (1.8.3)
-    kleisli (0.2.7)
     method_source (0.8.2)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -48,7 +47,6 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.10)
   codeclimate-test-reporter
-  dry-monads (= 0.0.1)
   dry-result_matcher!
   pry
   rake (~> 10.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,17 @@ GEM
   specs:
     codeclimate-test-reporter (0.5.0)
       simplecov (>= 0.7.1, < 1.0.0)
+    coderay (1.1.1)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    dry-monads (0.0.1)
     json (1.8.3)
     kleisli (0.2.7)
+    method_source (0.8.2)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rake (10.4.2)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
@@ -32,6 +39,7 @@ GEM
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    slop (3.6.0)
     yard (0.8.7.6)
 
 PLATFORMS
@@ -40,7 +48,9 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.10)
   codeclimate-test-reporter
+  dry-monads (= 0.0.1)
   dry-result_matcher!
+  pry
   rake (~> 10.4.2)
   rspec (~> 3.3.0)
   simplecov (~> 0.10.0)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Test Coverage](https://img.shields.io/codeclimate/coverage/github/dry-rb/dry-result_matcher.svg)][code_climate]
 [![API Documentation Coverage](http://inch-ci.org/github/dry-rb/dry-result_matcher.svg)][inch]
 
-An expressive, all-in-one API for operating on [Dry-Monads](https://github.com/dry-rb/dry-monads) `Either` results.
+An expressive, all-in-one API for operating on [dry-monads](https://github.com/dry-rb/dry-monads) `Either` results.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@
 [![Test Coverage](https://img.shields.io/codeclimate/coverage/github/dry-rb/dry-result_matcher.svg)][code_climate]
 [![API Documentation Coverage](http://inch-ci.org/github/dry-rb/dry-result_matcher.svg)][inch]
 
-An expressive, all-in-one API for operating on [Kleisli](https://github.com/txus/kleisli) `Either` results.
+An expressive, all-in-one API for operating on [Dry-Monads](https://github.com/dry-rb/dry-monads) or
+[Kleisli](https://github.com/txus/kleisli) `Either` results.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@
 [![Test Coverage](https://img.shields.io/codeclimate/coverage/github/dry-rb/dry-result_matcher.svg)][code_climate]
 [![API Documentation Coverage](http://inch-ci.org/github/dry-rb/dry-result_matcher.svg)][inch]
 
-An expressive, all-in-one API for operating on [Dry-Monads](https://github.com/dry-rb/dry-monads) or
-[Kleisli](https://github.com/txus/kleisli) `Either` results.
+An expressive, all-in-one API for operating on [Dry-Monads](https://github.com/dry-rb/dry-monads) `Either` results.
 
 ## Links
 

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+
+require 'bundler/setup'
+require 'dry-result_matcher'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+require 'pry'
+
+binding.pry

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/dry-result_matcher.gemspec
+++ b/dry-result_matcher.gemspec
@@ -17,9 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1.0"
 
-  # TODO: add runtime dependency once 'dry-monads' pushed to rubygems.org
-  # spec.add_runtime_dependency "dry-monads"
-  spec.add_runtime_dependency "kleisli"
+  spec.add_runtime_dependency "dry-monads", "~> 0.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.4.2"

--- a/dry-result_matcher.gemspec
+++ b/dry-result_matcher.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1.0"
 
+  # TODO: add runtime dependency once 'dry-monads' pushed to rubygems.org
+  # spec.add_runtime_dependency "dry-monads"
   spec.add_runtime_dependency "kleisli"
 
   spec.add_development_dependency "bundler", "~> 1.10"

--- a/lib/dry/result_matcher/matcher.rb
+++ b/lib/dry/result_matcher/matcher.rb
@@ -1,3 +1,4 @@
+require "dry-monads"
 require "kleisli"
 
 module Dry
@@ -6,18 +7,38 @@ module Dry
       attr_reader :result
       attr_reader :output
 
+      RIGHT = [
+        Dry::Monads::Either::Right,
+        Kleisli::Either::Right
+      ].freeze
+
+      LEFT = [
+        Dry::Monads::Either::Left,
+        Kleisli::Either::Left
+      ].freeze
+
       def initialize(result)
         @result = result
       end
 
       def success(&block)
-        return output unless result.is_a?(Kleisli::Either::Right)
+        return output unless is_a_right?
         @output = block.call(result.value)
       end
 
       def failure(&block)
-        return output unless result.is_a?(Kleisli::Either::Left)
+        return output unless is_a_left?
         @output = block.call(result.value)
+      end
+
+    private
+
+      def is_a_right?
+        RIGHT.include?(result.class)
+      end
+
+      def is_a_left?
+        LEFT.include?(result.class)
       end
     end
   end

--- a/lib/dry/result_matcher/matcher.rb
+++ b/lib/dry/result_matcher/matcher.rb
@@ -11,23 +11,13 @@ module Dry
       end
 
       def success(&block)
-        return output unless is_a_right?
+        return output unless result.right?
         @output = block.call(result.value)
       end
 
       def failure(&block)
-        return output unless is_a_left?
+        return output unless result.left?
         @output = block.call(result.value)
-      end
-
-    private
-
-      def is_a_right?
-        result.right?
-      end
-
-      def is_a_left?
-        result.left?
       end
     end
   end

--- a/lib/dry/result_matcher/matcher.rb
+++ b/lib/dry/result_matcher/matcher.rb
@@ -1,21 +1,10 @@
 require "dry-monads"
-require "kleisli"
 
 module Dry
   module ResultMatcher
     class Matcher
       attr_reader :result
       attr_reader :output
-
-      RIGHT = [
-        Dry::Monads::Either::Right,
-        Kleisli::Either::Right
-      ].freeze
-
-      LEFT = [
-        Dry::Monads::Either::Left,
-        Kleisli::Either::Left
-      ].freeze
 
       def initialize(result)
         @result = result
@@ -34,11 +23,11 @@ module Dry
     private
 
       def is_a_right?
-        RIGHT.include?(result.class)
+        result.right?
       end
 
       def is_a_left?
-        LEFT.include?(result.class)
+        result.left?
       end
     end
   end

--- a/lib/dry/result_matcher/matcher.rb
+++ b/lib/dry/result_matcher/matcher.rb
@@ -7,6 +7,7 @@ module Dry
       attr_reader :output
 
       def initialize(result)
+        result = result.to_either if result.respond_to?(:to_either)
         @result = result
       end
 

--- a/spec/integration/result_matcher_spec.rb
+++ b/spec/integration/result_matcher_spec.rb
@@ -1,16 +1,4 @@
 RSpec.describe Dry::ResultMatcher do
-  include Dry::Monads::Either::Mixin
-
-  describe 'Matcher RIGHT' do
-    subject { described_class::Matcher::RIGHT }
-    it { is_expected.to eq([Dry::Monads::Either::Right, Kleisli::Either::Right]) }
-  end
-
-  describe 'Matcher LEFT' do
-    subject { described_class::Matcher::LEFT }
-    it { is_expected.to eq([Dry::Monads::Either::Left, Kleisli::Either::Left]) }
-  end
-
   describe "external matching" do
     subject(:match) {
       Dry::ResultMatcher.match(result) do |m|
@@ -25,7 +13,7 @@ RSpec.describe Dry::ResultMatcher do
     }
 
     context "successful result" do
-      let(:result) { Right("a success") }
+      let(:result) { Dry::Monads::Right("a success") }
 
       it "matches on success" do
         expect(match).to eq "Matched success: a success"
@@ -33,7 +21,7 @@ RSpec.describe Dry::ResultMatcher do
     end
 
     context "failed result" do
-      let(:result) { Left("a failure") }
+      let(:result) { Dry::Monads::Left("a failure") }
 
       it "matches on failure" do
         expect(match).to eq "Matched failure: a failure"
@@ -47,7 +35,7 @@ RSpec.describe Dry::ResultMatcher do
         include Dry::ResultMatcher.for(:call)
 
         def call(bool)
-          bool ? Right("a success") : Left("a failure")
+          bool ? Dry::Monads::Right("a success") : Dry::Monads::Left("a failure")
         end
       end.new
     }
@@ -89,7 +77,7 @@ RSpec.describe Dry::ResultMatcher do
         let(:input) { true }
 
         it "returns the result" do
-          expect(result).to eq Right("a success")
+          expect(result).to eq Dry::Monads::Right("a success")
         end
       end
 
@@ -97,7 +85,7 @@ RSpec.describe Dry::ResultMatcher do
         let(:input) { false }
 
         it "returns the result" do
-          expect(result).to eq Left("a failure")
+          expect(result).to eq Dry::Monads::Left("a failure")
         end
       end
     end

--- a/spec/integration/result_matcher_spec.rb
+++ b/spec/integration/result_matcher_spec.rb
@@ -1,4 +1,16 @@
 RSpec.describe Dry::ResultMatcher do
+  include Dry::Monads::Either::Mixin
+
+  describe 'Matcher RIGHT' do
+    subject { described_class::Matcher::RIGHT }
+    it { is_expected.to eq([Dry::Monads::Either::Right, Kleisli::Either::Right]) }
+  end
+
+  describe 'Matcher LEFT' do
+    subject { described_class::Matcher::LEFT }
+    it { is_expected.to eq([Dry::Monads::Either::Left, Kleisli::Either::Left]) }
+  end
+
   describe "external matching" do
     subject(:match) {
       Dry::ResultMatcher.match(result) do |m|

--- a/spec/integration/result_matcher_spec.rb
+++ b/spec/integration/result_matcher_spec.rb
@@ -68,6 +68,34 @@ RSpec.describe Dry::ResultMatcher do
           expect(match).to eq "Matched failure: a failure"
         end
       end
+
+      context "result responds to #to_either" do
+        let(:operation) {
+          Class.new do
+            include Dry::ResultMatcher.for(:call)
+
+            def call(bool)
+              Dry::Monads::Try.lift([StandardError], -> { (bool) ? 'a success' : raise('a failure') })
+            end
+          end.new
+        }
+
+        context "successful result" do
+          let(:input) { true }
+
+          it "matches on success" do
+            expect(match).to eq "Matched success: a success"
+          end
+        end
+
+        context "failed result" do
+          let(:input) { false }
+
+          it "matches on failure" do
+            expect(match).to eq "Matched failure: a failure"
+          end
+        end
+      end
     end
 
     describe "without match blocks" do


### PR DESCRIPTION
Adds support for use of either Dry-Monads or Kleisli `Either`. **Important!** still a couple of flagged `#TODO`s as this will only work if you have the `dry-monads` gem installed locally. Once `dry-monads` has been pushed to rubygems.org this pull request can be updated and merged. Any additional feedback is welcomed.